### PR TITLE
Add netCDF4-python

### DIFF
--- a/MET/Dockerfile
+++ b/MET/Dockerfile
@@ -42,7 +42,7 @@ RUN yum -y update \
  && yum -y install gv ncview wgrib wgrib2 ImageMagick ps2pdf \
  && yum -y install python2 python2-pip python2-devel \
  && pip install --upgrade pip \
- && pip install xarray numpy
+ && pip install xarray numpy netcdf4
 
 #
 # Set working directory


### PR DESCRIPTION
Add netCDF4 to the python environment during the `pip install` step. This is not installed by default with Xarray and is required to use python for file IO of netCDF files.